### PR TITLE
Basic rate limiting for email notifications

### DIFF
--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -1,0 +1,125 @@
+use chrono::{DateTime, Duration, Utc};
+use std::collections::{HashMap, VecDeque};
+
+/// How often do we allow the same ip in the time frame
+const IP_LIMIT: usize = 100;
+const IP_WINDOW: Duration = Duration::seconds(10 * 60); // 10 minutes
+
+/// How often do we allow the same email to be registered in the time frame
+const EMAIL_LIMIT: usize = 30;
+const EMAIL_WINDOW: Duration = Duration::seconds(24 * 3600); //  1 day
+
+/// How often do we allow the same npub in the time frame
+const NPUB_LIMIT: usize = 100;
+const NPUB_WINDOW: Duration = Duration::seconds(10 * 60); // 10 minutes
+
+const MAX_IDLE: Duration = Duration::seconds(24 * 3600); // remove after 24h idle
+const PRUNE_INTERVAL: Duration = Duration::seconds(10 * 60); // check every 10 minutes
+
+#[derive(Debug)]
+struct SlidingWindow {
+    hits: VecDeque<DateTime<Utc>>,
+    window: Duration,
+    limit: usize,
+    last_seen: DateTime<Utc>,
+}
+
+impl SlidingWindow {
+    fn new(limit: usize, window: Duration) -> Self {
+        Self {
+            hits: VecDeque::new(),
+            window,
+            limit,
+            last_seen: Utc::now(),
+        }
+    }
+
+    fn allow(&mut self, now: DateTime<Utc>) -> bool {
+        // Remove expired hits
+        while let Some(&ts) = self.hits.front() {
+            if now - ts > self.window {
+                self.hits.pop_front();
+            } else {
+                break;
+            }
+        }
+        self.last_seen = now;
+
+        if self.hits.len() < self.limit {
+            self.hits.push_back(now);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RateLimiter {
+    by_ip: HashMap<String, SlidingWindow>,
+    by_email: HashMap<String, SlidingWindow>,
+    by_npub: HashMap<String, SlidingWindow>,
+    last_prune: DateTime<Utc>,
+}
+
+impl RateLimiter {
+    pub fn new() -> Self {
+        Self {
+            by_ip: HashMap::new(),
+            by_email: HashMap::new(),
+            by_npub: HashMap::new(),
+            last_prune: Utc::now(),
+        }
+    }
+
+    /// Check if the request is allowed
+    /// There is always an IP, but not always an email, or npub - everything that's set has to be allowed
+    /// The values are expected to be validated before getting in here
+    pub fn check(&mut self, ip: &str, email: Option<&str>, npub: Option<&str>) -> bool {
+        let now = Utc::now();
+        self.prune_if_needed(now);
+
+        let ip_ok = self
+            .by_ip
+            .entry(ip.to_string())
+            .or_insert_with(|| SlidingWindow::new(IP_LIMIT, IP_WINDOW))
+            .allow(now);
+
+        let email_ok = if let Some(email) = email {
+            let key = email.to_lowercase();
+            self.by_email
+                .entry(key)
+                .or_insert_with(|| SlidingWindow::new(EMAIL_LIMIT, EMAIL_WINDOW))
+                .allow(now)
+        } else {
+            true // no email provided -> skip check
+        };
+
+        let npub_ok = if let Some(npub) = npub {
+            self.by_npub
+                .entry(npub.to_string())
+                .or_insert_with(|| SlidingWindow::new(NPUB_LIMIT, NPUB_WINDOW))
+                .allow(now)
+        } else {
+            true // no npub provided -> skip check
+        };
+
+        ip_ok && email_ok && npub_ok
+    }
+
+    /// Every PRUNE_INTERVAL, remove outdated entries
+    fn prune_if_needed(&mut self, now: DateTime<Utc>) {
+        if now - self.last_prune < PRUNE_INTERVAL {
+            return;
+        }
+
+        self.last_prune = now;
+
+        // only keep recent entries
+        self.by_ip.retain(|_, win| now - win.last_seen <= MAX_IDLE);
+        self.by_email
+            .retain(|_, win| now - win.last_seen <= MAX_IDLE);
+        self.by_npub
+            .retain(|_, win| now - win.last_seen <= MAX_IDLE);
+    }
+}


### PR DESCRIPTION
### **User description**
Basic implementation of an in-memory, sliding-window based rate-limiting mechanism that checks ip, email and npub and rate-limits if they are used more than a configured amount in a configured timespan.


___

### **PR Type**
Enhancement


___

### **Description**
- Add sliding-window rate limiting for email notifications

- Implement IP, email, and npub-based rate limiting

- Add rate limit checks to notification endpoints

- Include automatic cleanup of expired rate limit entries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Request"] --> B["Rate Limiter Check"]
  B --> C["IP Rate Limit"]
  B --> D["Email Rate Limit"]
  B --> E["Npub Rate Limit"]
  C --> F["Allow/Deny"]
  D --> F
  E --> F
  F --> G["Process Request"]
  F --> H["Return 429 Too Many Requests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Integrate rate limiter into application state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs

<ul><li>Add <code>rate_limit</code> module import<br> <li> Include <code>RateLimiter</code> in <code>AppState</code> with mutex protection<br> <li> Initialize rate limiter in application state</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/bcr-relay/pull/6/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+12/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add rate limiting to notification endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/notification/mod.rs

<ul><li>Add <code>ConnectInfo</code> extraction for client IP addresses<br> <li> Implement rate limiting checks in <code>start</code>, <code>register</code>, and <code>send</code> endpoints<br> <li> Return 429 status code when rate limits are exceeded<br> <li> Add warning logs for rate-limited requests</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/bcr-relay/pull/6/files#diff-69d65b2da7072927b928b05c5abaada22ca35373dc71ec33f09ecf2780a484da">+59/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rate_limit.rs</strong><dd><code>Implement sliding-window rate limiting mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rate_limit.rs

<ul><li>Implement <code>SlidingWindow</code> struct for time-based rate limiting<br> <li> Create <code>RateLimiter</code> with separate limits for IP, email, and npub<br> <li> Add automatic pruning of expired rate limit entries<br> <li> Configure different limits and windows for each identifier type</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/bcr-relay/pull/6/files#diff-db45b3a5762a99af7cfa7f61e9255d996fe6041592e319f1132e93b62a555c20">+125/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

