### PR TITLE
Name the copyright holder consistently

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Bitcredit
+Copyright (c) 2025 Bitcredit Protocol
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The organisation's licence files carry two different holders — `Bitcredit` in four of the oldest repositories, `Bitcredit Protocol` in the other twenty-two.

```diff
- Copyright (c) 2025 Bitcredit
+ Copyright (c) 2025 Bitcredit Protocol
```

A copyright notice names a legal subject, so two of them across one codebase is a question best not left for later. `Bitcredit Protocol` is the majority form and matches the organisation name.

The year is untouched — it records first publication. The licence body is byte-identical to every other MIT file in the organisation.

Three other repositories get the same change: `.github`, `Bitcredit-Core`, `ui`, `bcr-relay`. `Bootstrap-Node` carries the old form too but is archived and therefore read-only. `nostr-postgres-db` keeps `Rust Nostr Developers` — that is derived third-party code and its holder is not ours to rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)