### PR TITLE
Assign Dependabot pull requests to zupzup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,4 @@ updates:
       - "dependencies"
       - "github-actions"
     assignees:
-      - "cleot" # devops maintainer
+      - "zupzup"


### PR DESCRIPTION
`assignees` was set on the `cleot` block only, so every `github-actions` pull request has been opening with no assignee at all.

This sets the assignee to `zupzup` on every update block, per the mapping in [`dependabot-assignees.yml`](https://github.com/BitcreditProtocol/.github/blob/master/dependabot-assignees.yml). The weekly settings audit now reports any repository whose configuration disagrees with that file, so it cannot drift back unnoticed — and a repository added later shows up in the report instead of silently starting with no reviewer.

Nothing else changes: same schedule, same grouping, same ignore rules.
