### PR TITLE
Cooldown on action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:
-      github-actions:
+      all-github-actions:
         patterns:
           - "*"
     schedule:
@@ -15,5 +15,9 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     assignees:
       - "zupzup"


### PR DESCRIPTION
Two changes, one commit each.

## Cooldown on the `github-actions` block

Every package block in this organisation has carried a cooldown for months — thirty days on a major, seven on a minor, three on a patch. The `github-actions` block never had one, which is backwards: an action runs inside the job, with the job's token and secrets, while an npm package usually just sits in `node_modules`.

A compromised release is normally pulled within days. Three days on a patch is the difference between adopting one and reading about it.

The group is also renamed `github-actions` → `all-github-actions`, the name the other repositories use, so pull request titles and branch names read the same everywhere.

## Verification

Both files parse, and the diffs were checked line by line before pushing: the config diff contains only `cooldown` and group lines, the workflow diff only `uses:` lines. Across the organisation this pins 39 references and leaves no moving tag behind.
